### PR TITLE
Add support for custom extensions

### DIFF
--- a/index.js
+++ b/index.js
@@ -188,6 +188,13 @@ var GulpWebdriverIO = function(args) {
 
         GLOBAL.browser.init(function(err) {
             /**
+             *  Allow for adding custom commands
+             */
+            if("function" === typeof args.applyExtensions){
+                args.applyExtensions.call(null, this);
+            }
+            
+            /**
              * gracefully kill process if init fails
              */
             callback(err);


### PR DESCRIPTION
I've been working on [jimschubert/electron-aurelia-example](https://github.com/jimschubert/electron-aurelia-example), combining atom/electron and aurelia/skeleton-navigation into a desktop application example. I have end to end tests working with a few modifications, one of which was a need to add custom commends to the webdriver client.

I added this functionality with an `applyExtensions` property on the configuration object, which expects a `function(client)` signature. This allows me to extend webdriver with, most importantly, 

```
  client.addCommand('waitForAureliaPage', function(cb){
    this.executeAsync(function(done){
      document.addEventListener("aurelia-composed", function (e) {
        done(true)
      });
    }, cb);
  });
```
