### PR TITLE
Only cause mocha to fail on failed tests.

### DIFF
--- a/index.js
+++ b/index.js
@@ -215,9 +215,11 @@ var GulpWebdriverIO = function(args) {
         gutil.log('end selenium session');
 
         if (!options.user && !options.key && !options.updateSauceJob) {
-            this.emit('error', new gutil.PluginError('gulp-webdriver', result + ' ' + (result === 1 ? 'test' : 'tests') + ' failed.', {
-                showStack: false
-            }));
+            if(result !== 0) { 
+                this.emit('error', new gutil.PluginError('gulp-webdriver', result + ' ' + (result === 1 ? 'test' : 'tests') + ' failed.', {
+                    showStack: false
+                }));
+            }
         }
 
         // Close Remote sessions if needed


### PR DESCRIPTION
Emitting an error when the results from mocha are 0 causes gulp to incorrectly report an error:

```
[22:03:27] run mocha tests


  aurelia skeleton app
    ✓ should load the page and display the initial page title
    ✓ should display greeting (47ms)
    ✓ should automatically write down the fullname (1457ms)
    ✓ should show alert message when clicking submit button
    ✓ should navigate to flickr page (541ms)


  5 passing (21s)

[22:03:48] 'specs:e2e' errored after 22 s
[22:03:48] Error in plugin 'gulp-webdriver'
Message:
    0 tests failed.
[22:03:48] 'specs' errored after 29 s
[22:03:48] Error: [object Object]
    at formatError (/usr/local/lib/node_modules/gulp/bin/gulp.js:169:10)
    at Gulp.<anonymous> (/usr/local/lib/node_modules/gulp/bin/gulp.js:195:15)
    at Gulp.emit (events.js:129:20)
    at Gulp.Orchestrator._emitTaskDone (/Users/jim/temp/electron-aurelia-example/node_modules/gulp/node_modules/orchestrator/index.js:264:8)
    at /Users/jim/temp/electron-aurelia-example/node_modules/gulp/node_modules/orchestrator/index.js:275:23
    at finish (/Users/jim/temp/electron-aurelia-example/node_modules/gulp/node_modules/orchestrator/lib/runTask.js:21:8)
    at cb (/Users/jim/temp/electron-aurelia-example/node_modules/gulp/node_modules/orchestrator/lib/runTask.js:29:3)
    at finish (/Users/jim/temp/electron-aurelia-example/node_modules/run-sequence/index.js:53:5)
    at Gulp.onError (/Users/jim/temp/electron-aurelia-example/node_modules/run-sequence/index.js:60:4)
    at Gulp.emit (events.js:129:20)
[22:03:48] ended selenium session
```

Wrapping the broadcast of the event in a check prevents this.
