### PR TITLE
Fix for missing support of Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,8 +13,7 @@ module.exports = function(options) {
 
         var stream = this,
             configFile = file.path,
-            base = process.cwd(),
-            wdioBin = path.join(base, 'node_modules', 'webdriverio', 'bin') + '/wdio';
+            wdioBin = path.join(__dirname, 'node_modules', '.bin', 'wdio');
 
         var opts = deepmerge({
             wdioBin: wdioBin

--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@ module.exports = function(options) {
 
         var stream = this,
             configFile = file.path,
-            wdioBin = path.join(__dirname, 'node_modules', '.bin', 'wdio');
+            isWin = /^win/.test(process.platform),
+            wdioBin = path.join(__dirname, 'node_modules', '.bin', isWin ? 'wdio.cmd' : 'wdio');
 
         var opts = deepmerge({
             wdioBin: wdioBin

--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
     "gulp-util": "^3.0.4",
     "through2": "^0.6.5",
     "deepmerge": "^0.2.7",
-    "dargs": "christian-bromann/dargs"
+    "dargs": "christian-bromann/dargs",
+    "webdriverio": "^3.2.1"
   },
   "devDependencies": {
     "gulp": "^3.8.11",
-    "mocha": "^2.3.0",
-    "webdriverio": "^3.2.1"
+    "mocha": "^2.3.0"
   }
 }


### PR DESCRIPTION
- made webdriverio package to be a direct dependency (instead of dev-only)
- fixed wdioBin construction to be more solid
- fixed missing platform specific construction of wdioBin value
