### PR TITLE
Bug fix for when no webdriver options are passed in.

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = function(options) {
 
         var opts = deepmerge({
             wdioBin: wdioBin
-        }, options);
+        }, options || {});
 
         /**
          * check webdriverio dependency


### PR DESCRIPTION
The following error is thrown when the "options" variable is undefined, making the first example in the README invalid.

``` javascript
/home/user/Projects/test/node_modules/gulp-webdriver/node_modules/deepmerge/index.js:35
        Object.keys(src).forEach(function (key) {
               ^
TypeError: Object.keys called on non-object
    at Function.keys (native)
    at deepmerge (/home/user/Projects/test/node_modules/gulp-webdriver/node_modules/deepmerge/index.js:35:16)
    at DestroyableTransform._transform (/home/user/Projects/test/node_modules/gulp-webdriver/index.js:19:20)
    at DestroyableTransform.Transform._read (/home/user/Projects/test/node_modules/gulp-webdriver/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:184:10)
    at DestroyableTransform.Transform._write (/home/user/Projects/test/node_modules/gulp-webdriver/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:172:12)
    at doWrite (/home/user/Projects/test/node_modules/gulp-webdriver/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:237:10)
    at writeOrBuffer (/home/user/Projects/test/node_modules/gulp-webdriver/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:227:5)
    at DestroyableTransform.Writable.write (/home/user/Projects/test/node_modules/gulp-webdriver/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:194:11)
    at write (/home/user/Projects/test/node_modules/gulp/node_modules/vinyl-fs/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:623:24)
    at flow (/home/user/Projects/test/node_modules/gulp/node_modules/vinyl-fs/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:632:7)
```
