### PR TITLE
fixed path for wdio.cmd

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = function(options) {
         var stream = this,
             configFile = file.path,
             isWin = /^win/.test(process.platform),
-            wdioBin = require.resolve(path.join('webdriverio', 'bin', isWin ? 'wdio.cmd' : 'wdio'));
+            wdioBin = require.resolve(path.join('webdriverio', '../.bin', isWin ? 'wdio.cmd' : 'wdio'));
 
         var opts = deepmerge({
             wdioBin: wdioBin


### PR DESCRIPTION
It is an error in the windows environment.

```
$ npm test

> gulp-webdriver@1.0.2 test d:\home\gulp-webdriver
> gulp webdriver

[16:46:36] Using gulpfile d:\home\gulp-webdriver\gulpfile.js
[16:46:36] Starting 'webdriver'...
module.js:339
    throw err;
    ^

Error: Cannot find module 'webdriverio\bin\wdio.cmd'
    at Function.Module._resolveFilename (module.js:337:15)
```

Fixed path for `wdio.cmd`.

```
webdriverio/bin -> webdriverio/../.bin (node_modules/.bin)
```

```
node_modules/.bin
  wdio          // shell
  wdio.cmd  // windows bat file

webdriverio/bin
  wdio         // node.js file
```
