### PR TITLE
pass filename as first argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports = function(options) {
             }));
         }
 
-        var args = process.execArgv.concat([configFile]).concat(dargs(opts, {
+        var args = ([configFile]).concat(process.execArgv).concat(dargs(opts, {
             excludes: ['wdioBin'],
             keepCamelCase: true
         }));


### PR DESCRIPTION
The wdio [cli ](https://github.com/webdriverio/webdriverio/blob/f44e8e48e93eb8b3640c550f0082019a5d1e455d/lib/cli.js#L99) takes the first arg as the filename. This pull request is to ensure that the first argument passed in from gulp-webdriver is the filename. In my case, I am including the `harmony` flag and that is getting pulled in first
