### PR TITLE
Bumped WebdriverIO v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,17 @@ gulp-webdriver [![Build Status](https://travis-ci.org/webdriverio/gulp-webdriver
 npm install gulp-webdriver --save-dev
 ```
 
+## WDIO Version Compatibility
+
+There are breaking changes between WDIO v4 and v5. 
+
+The chart below shows the versions of this plugin and their WDIO compatibility version.
+
+| gulp-webdriver | WDIO |
+| -------------- | ---- |
+|     ^2.0.2     |  v4  |
+|     ^3.0.0     |  v5  |
+
 ## Usage
 
 You can run WebdriverIO locally by running this simple task:
@@ -54,3 +65,4 @@ maintain the existing coding style.
 * 2016-03-16   v2.0.0       updated codebase to ES6 and WebdriverIO to v4.0
 * 2016-03-30   v2.0.1       improved error handling
 * 2016-07-06   v2.0.2       fixed bug where gulp end event was not fired
+* 2019-07-13   v3.0.0       bumped WebdriverIO version to 5.11.2

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "through2": "^2.0.3"
   },
   "peerDependencies": {
-    "webdriverio": "^4.1.1"
+    "webdriverio": "^4.1.1",
+    "@wdio/cli": "^5.11.2"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,10 @@
 import through from 'through2'
-import resolve from 'resolve'
-import path from 'path'
 import gutil from 'gulp-util'
+import Launcher from '@wdio/cli/build/launcher'
 
 module.exports = (options) => {
     return through.obj(function (file, encoding, callback) {
         let stream = this
-        let Launcher = require(path.join(path.dirname(resolve.sync('webdriverio')), 'lib/launcher'))
         let wdio = new Launcher(file.path, options)
 
         wdio.run().then(code => {


### PR DESCRIPTION
Hi,

Updated the files based on wdio v5 support.

Execution Verified.

Lint errors Verified.

Removed import of unused module path & resolve. As resolve.sync is not supported to retrieve path of module with special character at starting (@wdio). 